### PR TITLE
Add batch enroll verified authenticators method

### DIFF
--- a/src/Authsignal.cs
+++ b/src/Authsignal.cs
@@ -185,6 +185,20 @@ public class AuthsignalClient : IAuthsignalClient
         return JsonSerializer.Deserialize<EnrollVerifiedAuthenticatorResponse>(content, _serializeOptions)!;
     }
 
+    public async Task<BatchEnrollVerifiedAuthenticatorsResponse> BatchEnrollVerifiedAuthenticators(BatchEnrollVerifiedAuthenticatorsRequest request, CancellationToken cancellationToken = default)
+    {
+        var httpRequest = new AuthsignalHttpRequest(HttpMethod.Post, "users/authenticators")
+        {
+            Content = new StringContent(JsonSerializer.Serialize(request, _serializeOptions), Encoding.UTF8, "application/json")
+        };
+
+        using var response = await SendHttpRequest(httpRequest, cancellationToken);
+
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+        return JsonSerializer.Deserialize<BatchEnrollVerifiedAuthenticatorsResponse>(content, _serializeOptions)!;
+    }
+
     public async Task DeleteAuthenticator(DeleteAuthenticatorRequest request, CancellationToken cancellationToken = default)
     {
         var httpRequest = new AuthsignalHttpRequest(HttpMethod.Delete, $"users/{request.UserId}/authenticators/{request.UserAuthenticatorId}");

--- a/src/IAuthsignalClient.cs
+++ b/src/IAuthsignalClient.cs
@@ -14,6 +14,8 @@ public interface IAuthsignalClient
 
     Task<EnrollVerifiedAuthenticatorResponse> EnrollVerifiedAuthenticator(EnrollVerifiedAuthenticatorRequest request, CancellationToken cancellationToken = default);
 
+    Task<BatchEnrollVerifiedAuthenticatorsResponse> BatchEnrollVerifiedAuthenticators(BatchEnrollVerifiedAuthenticatorsRequest request, CancellationToken cancellationToken = default);
+
     Task DeleteAuthenticator(DeleteAuthenticatorRequest request, CancellationToken cancellationToken = default);
 
     Task<TrackResponse> Track(TrackRequest request, CancellationToken cancellationToken = default);

--- a/src/Models.cs
+++ b/src/Models.cs
@@ -186,6 +186,34 @@ public record class EnrollVerifiedAuthenticatorResponse(
     List<string> RecoveryCodes
 );
 
+public record class BatchEnrollVerifiedAuthenticatorsRequest(
+    BatchEnrollAuthenticatorItem[] Authenticators
+);
+
+public record class BatchEnrollAuthenticatorItem(
+    string UserId,
+    VerificationMethod VerificationMethod,
+    string CredentialId,
+    string CredentialPublicKey,
+    string? Name = null,
+    string[]? Transports = null,
+    string? Aaguid = null
+);
+
+public record class BatchEnrollVerifiedAuthenticatorsResponse(
+    int Total,
+    int Succeeded,
+    int Failed,
+    BatchEnrollFailure[] Failures
+);
+
+public record class BatchEnrollFailure(
+    string UserId,
+    string CredentialId,
+    string ErrorCode,
+    string ErrorDescription
+);
+
 public record class DeleteAuthenticatorRequest(
     string UserId,
     string UserAuthenticatorId

--- a/src/authsignal-dotnet.csproj
+++ b/src/authsignal-dotnet.csproj
@@ -12,13 +12,13 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageTags>Authsignal, MFA, 2FA, Authentication, Passwordless, Passkeys</PackageTags>
 		<RepositoryUrl>https://github.com/authsignal/authsignal-dotnet</RepositoryUrl>
-		<Version>4.1.0</Version>
+		<Version>4.2.0</Version>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>embedded</DebugType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageReleaseNotes>https://github.com/authsignal/authsignal-dotnet/releases/tag/v4.1.0</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/authsignal/authsignal-dotnet/releases/tag/v4.2.0</PackageReleaseNotes>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
### New Features
- Adds `BatchEnrollVerifiedAuthenticators` to `IAuthsignalClient` / `AuthsignalClient`, posting to `users/authenticators` to enroll multiple WebAuthn credentials in a single request.
- Adds supporting models: `BatchEnrollVerifiedAuthenticatorsRequest`, `BatchEnrollAuthenticatorItem`, `BatchEnrollVerifiedAuthenticatorsResponse`, `BatchEnrollFailure`.

### Checklist
- [ ] Version bumped
- [ ] Documentation updated