### PR TITLE
Support structured webhook data and log event batches

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - run: dotnet test authsignal-dotnet.sln --configuration Release
+
       - name: Check tag matches csproj version
         if: github.event_name == 'release'
         run: |

--- a/src/Authsignal.cs
+++ b/src/Authsignal.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -18,7 +19,9 @@ public class AuthsignalClient : IAuthsignalClient
 
     public Webhook Webhook { get => _webhook; }
 
-    private static readonly string _version = "4.1.0";
+    private static readonly string _version = typeof(AuthsignalClient).Assembly
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+        .InformationalVersion.Split('+')[0] ?? "unknown";
 
     internal AuthsignalClient(IHttpClientFactory httpClientFactory, string apiSecretKey, string? apiUrl = null, int? retries = null)
     {

--- a/src/Models.cs
+++ b/src/Models.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Authsignal;
@@ -441,5 +442,10 @@ public record class WebhookEvent(
     string Source,
     string Time,
     string TenantId,
-    Dictionary<string, string>? Data
+    Dictionary<string, JsonElement>? Data = null,
+    Dictionary<string, JsonElement>? Record = null
+);
+
+public record class WebhookEventBatch(
+    List<WebhookEvent> Records
 );

--- a/src/Webhook.cs
+++ b/src/Webhook.cs
@@ -21,6 +21,73 @@ namespace Authsignal
 
         public WebhookEvent ConstructEvent(string payload, string signature, int tolerance = DEFAULT_TOLERANCE)
         {
+            VerifySignature(payload, signature, tolerance);
+
+            if (IsLogEventBatch(payload))
+            {
+                throw new InvalidPayloadException("Payload is a batch of log events. Use ConstructLogEventBatch instead.");
+            }
+
+            var webhookEvent = DeserializePayload<WebhookEvent>(payload);
+
+            ValidateEvent(webhookEvent, expectsRecord: false);
+
+            return webhookEvent;
+        }
+
+        public WebhookEventBatch ConstructLogEventBatch(string payload, string signature, int tolerance = DEFAULT_TOLERANCE)
+        {
+            VerifySignature(payload, signature, tolerance);
+
+            var batch = DeserializePayload<WebhookEventBatch>(payload);
+
+            if (batch.Records == null)
+            {
+                throw new InvalidPayloadException("Payload format is invalid. Expected a 'records' array.");
+            }
+
+            foreach (var webhookEvent in batch.Records)
+            {
+                ValidateEvent(webhookEvent, expectsRecord: true);
+            }
+
+            return batch;
+        }
+
+        private static void ValidateEvent(WebhookEvent webhookEvent, bool expectsRecord)
+        {
+            if (webhookEvent.Version <= 0)
+            {
+                throw new InvalidPayloadException("Payload is missing required field 'version'.");
+            }
+
+            RequireField(webhookEvent.Type, "type");
+            RequireField(webhookEvent.Id, "id");
+            RequireField(webhookEvent.Source, "source");
+            RequireField(webhookEvent.Time, "time");
+            RequireField(webhookEvent.TenantId, "tenantId");
+
+            if (expectsRecord && webhookEvent.Record == null)
+            {
+                throw new InvalidPayloadException("Payload is missing required field 'record'.");
+            }
+
+            if (!expectsRecord && webhookEvent.Data == null)
+            {
+                throw new InvalidPayloadException("Payload is missing required field 'data'.");
+            }
+        }
+
+        private static void RequireField(string? value, string name)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidPayloadException($"Payload is missing required field '{name}'.");
+            }
+        }
+
+        private void VerifySignature(string payload, string signature, int tolerance)
+        {
             var parsedSignature = ParseSignature(signature);
 
             long secondsSinceEpoch = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
@@ -40,15 +107,41 @@ namespace Authsignal
             {
                 throw new InvalidSignatureException("Signature mismatch.");
             }
+        }
 
-            WebhookEvent? webhookEvent = JsonSerializer.Deserialize<WebhookEvent>(payload, serializerOptions);
-
-            if (webhookEvent == null)
+        private T DeserializePayload<T>(string payload) where T : class
+        {
+            try
             {
-                throw new InvalidSignatureException("Payload format is invalid.");
-            }
+                var result = JsonSerializer.Deserialize<T>(payload, serializerOptions);
 
-            return webhookEvent;
+                if (result == null)
+                {
+                    throw new InvalidPayloadException("Payload format is invalid.");
+                }
+
+                return result;
+            }
+            catch (JsonException exception)
+            {
+                throw new InvalidPayloadException("Payload format is invalid.", exception);
+            }
+        }
+
+        private static bool IsLogEventBatch(string payload)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(payload);
+
+                return document.RootElement.ValueKind == JsonValueKind.Object
+                    && document.RootElement.TryGetProperty("records", out var records)
+                    && records.ValueKind == JsonValueKind.Array;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
         }
 
         private SignatureHeaderData ParseSignature(string value)
@@ -120,5 +213,12 @@ namespace Authsignal
         }
 
         public class InvalidSignatureException(string message) : Exception(message) { }
+
+        public class InvalidPayloadException : Exception
+        {
+            public InvalidPayloadException(string message) : base(message) { }
+
+            public InvalidPayloadException(string message, Exception innerException) : base(message, innerException) { }
+        }
     }
 }

--- a/src/authsignal-dotnet.csproj
+++ b/src/authsignal-dotnet.csproj
@@ -12,13 +12,13 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageTags>Authsignal, MFA, 2FA, Authentication, Passwordless, Passkeys</PackageTags>
 		<RepositoryUrl>https://github.com/authsignal/authsignal-dotnet</RepositoryUrl>
-		<Version>4.4.0</Version>
+		<Version>5.0.0</Version>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>embedded</DebugType>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageReleaseNotes>https://github.com/authsignal/authsignal-dotnet/releases/tag/v4.4.0</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/authsignal/authsignal-dotnet/releases/tag/v5.0.0</PackageReleaseNotes>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/tests/ClientTests.cs
+++ b/tests/ClientTests.cs
@@ -2,7 +2,7 @@
 
 public class ClientTests : TestBase
 {
-    [Fact]
+    [IntegrationFact]
     public async Task TestUser()
     {
         var userId = Guid.NewGuid().ToString();
@@ -58,7 +58,7 @@ public class ClientTests : TestBase
         Assert.False(deletedUserResponse.IsEnrolled);
     }
 
-    [Fact]
+    [IntegrationFact]
     public async Task TestAuthenticator()
     {
         var userId = Guid.NewGuid().ToString();
@@ -96,7 +96,7 @@ public class ClientTests : TestBase
         Assert.Empty(emptyAuthenticatorsResponse);
     }
 
-    [Fact]
+    [IntegrationFact]
     public async Task TestAction()
     {
         var userId = Guid.NewGuid().ToString();
@@ -152,30 +152,25 @@ public class ClientTests : TestBase
         Assert.Equal(UserActionState.REVIEW_REQUIRED, actionResponse.State);
     }
 
-    [Fact]
+    [IntegrationFact]
     public async Task TestInvalidSecretError()
     {
-        var baseUrl = Configuration["BaseUrl"]!;
+        var apiUrl = Configuration["ApiUrl"]!;
 
         var secret = "invalid_secret";
 
-        var client = new AuthsignalClient(secret, baseUrl);
+        var client = new AuthsignalClient(secret, apiUrl);
 
         var userRequest = new GetUserRequest(UserId: Guid.NewGuid().ToString());
 
-        try
-        {
-            var userResponse = await client.GetUser(userRequest);
-        }
-        catch (AuthsignalException e)
-        {
-            Assert.Equal(401, e.StatusCode);
-            Assert.Equal("unauthorized", e.Error);
-            Assert.Equal("The request is unauthorized. Check that your API key and region base URL are correctly configured.", e.ErrorDescription);
-        }
+        var exception = await Assert.ThrowsAsync<AuthsignalException>(() => client.GetUser(userRequest));
+
+        Assert.Equal(401, exception.StatusCode);
+        Assert.Equal("unauthorized", exception.Error);
+        Assert.Equal("The request is unauthorized. Check that your API key and region base URL are correctly configured.", exception.ErrorDescription);
     }
 
-    [Fact]
+    [IntegrationFact]
     public async Task TestPasskeyAuthenticator()
     {
         var userId = "b60429a1-6288-43dc-80c0-6a3e73dd51b9";

--- a/tests/IntegrationFactAttribute.cs
+++ b/tests/IntegrationFactAttribute.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+
+namespace Authsignal.Tests;
+
+public sealed class IntegrationFactAttribute : FactAttribute
+{
+    private const string PlaceholderApiSecretKey = "YOUR_API_SECRET_KEY";
+
+    public IntegrationFactAttribute()
+    {
+        var configurationPath = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
+
+        if (!File.Exists(configurationPath))
+        {
+            Skip = "Integration tests require tests/appsettings.json.";
+            return;
+        }
+
+        using var configuration = JsonDocument.Parse(File.ReadAllText(configurationPath));
+
+        if (!configuration.RootElement.TryGetProperty("ApiSecretKey", out var apiSecretKey)
+            || string.IsNullOrWhiteSpace(apiSecretKey.GetString())
+            || apiSecretKey.GetString() == PlaceholderApiSecretKey)
+        {
+            Skip = "Integration tests require a configured Authsignal API secret key.";
+        }
+    }
+}

--- a/tests/WebhookTests.cs
+++ b/tests/WebhookTests.cs
@@ -1,7 +1,21 @@
+using System.Security.Cryptography;
+using System.Text;
+
 namespace Authsignal.Tests;
 
 public class WebhookTests : TestBase
 {
+    private string SignPayload(string payload, long timestamp)
+    {
+        var apiSecretKey = Configuration["ApiSecretKey"]!;
+
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(apiSecretKey));
+
+        var hmacBytes = hmac.ComputeHash(Encoding.UTF8.GetBytes($"{timestamp}.{payload}"));
+
+        return $"t={timestamp},v2={Convert.ToBase64String(hmacBytes).TrimEnd('=')}";
+    }
+
     [Fact]
     public void TestInvalidSignatureFormat()
     {
@@ -42,18 +56,12 @@ public class WebhookTests : TestBase
     public void TestInvalidComputedSignature()
     {
         string payload = "{}";
-        string signature = "t=1630000000,v2=invalid_signature";
+        string signature = $"t={DateTimeOffset.UtcNow.ToUnixTimeSeconds()},v2=invalid_signature";
 
-        try
-        {
-            AuthsignalClient.Webhook.ConstructEvent(payload, signature);
+        var ex = Assert.Throws<Webhook.InvalidSignatureException>(
+            () => AuthsignalClient.Webhook.ConstructEvent(payload, signature));
 
-            Assert.Fail("Expected an AuthsignalException to be thrown");
-        }
-        catch (Webhook.InvalidSignatureException ex)
-        {
-            Assert.Equal("Timestamp is outside the tolerance zone.", ex.Message);
-        }
+        Assert.Equal("Signature mismatch.", ex.Message);
     }
 
     [Fact]
@@ -78,24 +86,17 @@ public class WebhookTests : TestBase
 
         int tolerance = -1;
 
-        string signature = "t=1740016316,v2=NwFcIT68pK7g+m365Jj4euXj/ke3GSnkTpMPcRVi5q4";
+        string signature = SignPayload(payload, 1740016316);
 
-        try
-        {
-            var eventObj = AuthsignalClient.Webhook.ConstructEvent(payload, signature, tolerance);
+        var eventObj = AuthsignalClient.Webhook.ConstructEvent(payload, signature, tolerance);
 
-            Assert.NotNull(eventObj);
+        Assert.NotNull(eventObj);
 
-            Assert.Equal(1, eventObj.Version);
+        Assert.Equal(1, eventObj.Version);
 
-            var actionCode = eventObj.Data?.GetValueOrDefault("actionCode");
+        var actionCode = eventObj.Data?.GetValueOrDefault("actionCode").GetString();
 
-            Assert.Equal("accountRecovery", actionCode);
-        }
-        catch
-        {
-            Assert.Fail("Expected a valid event to be constructed");
-        }
+        Assert.Equal("accountRecovery", actionCode);
     }
 
     [Fact]
@@ -120,16 +121,122 @@ public class WebhookTests : TestBase
 
         int tolerance = -1;
 
-        string signature = "t=1740016037,v2=zI5rg1XJtKH8dXTX9VCSwy07qTPJliXkK9ppgNjmzqw,v2=KMg8mXXGO/SmNNmcszKXI4UaEVHLc21YNWthHfispQo";
+        string signature = $"{SignPayload(payload, 1740016037)},v2=invalid_signature";
 
-        try
-        {
-            var eventObj = AuthsignalClient.Webhook.ConstructEvent(payload, signature, tolerance);
-            Assert.NotNull(eventObj);
-        }
-        catch
-        {
-            Assert.Fail("Expected a valid event to be constructed");
-        }
+        var eventObj = AuthsignalClient.Webhook.ConstructEvent(payload, signature, tolerance);
+
+        Assert.NotNull(eventObj);
+    }
+
+    [Fact]
+    public void TestEventWithCustomVariables()
+    {
+        string payload = "{"
+               + "\"version\":1,"
+               + "\"id\":\"7f0d5e6a-3c1b-4a2e-9d8f-5b6c7a8e9f01\","
+               + "\"source\":\"https://authsignal.com\","
+               + "\"time\":\"2025-02-20T01:51:56.070Z\","
+               + "\"tenantId\":\"7752d28e-e627-4b1b-bb81-b45d68d617bc\","
+               + "\"type\":\"sms.created\","
+               + "\"data\":{"
+               + "\"code\":\"123456\","
+               + "\"to\":\"+919888123456\","
+               + "\"userId\":\"b9f74d36-fcfc-4efc-87f1-3664ab5a7fb0\","
+               + "\"actionCode\":\"smsVerify\","
+               + "\"customVariables\":{"
+               + "\"action_journeyType\":\"ForgotChangePassword\","
+               + "\"action_transactionAmount\":100,"
+               + "\"user_isVerified\":true,"
+               + "\"user_roles\":[\"admin\",\"ops\"]"
+               + "}"
+               + "}"
+               + "}";
+
+        int tolerance = -1;
+
+        string signature = SignPayload(payload, 1740016316);
+
+        var eventObj = AuthsignalClient.Webhook.ConstructEvent(payload, signature, tolerance);
+
+        Assert.NotNull(eventObj);
+
+        Assert.Equal("smsVerify", eventObj.Data?.GetValueOrDefault("actionCode").GetString());
+
+        var customVariables = eventObj.Data?.GetValueOrDefault("customVariables");
+
+        Assert.Equal("ForgotChangePassword", customVariables?.GetProperty("action_journeyType").GetString());
+
+        Assert.Equal(100, customVariables?.GetProperty("action_transactionAmount").GetInt32());
+
+        Assert.True(customVariables?.GetProperty("user_isVerified").GetBoolean());
+
+        Assert.Equal("admin", customVariables?.GetProperty("user_roles")[0].GetString());
+    }
+
+    [Fact]
+    public void TestLogEventBatch()
+    {
+        string payload = "{"
+               + "\"records\":[{"
+               + "\"version\":1,"
+               + "\"id\":\"5d1d6b5c-4b6f-4f5a-9c3e-2f7a1b8d4e6c\","
+               + "\"source\":\"https://authsignal.com\","
+               + "\"time\":\"2025-02-20T01:51:56.070Z\","
+               + "\"tenantId\":\"7752d28e-e627-4b1b-bb81-b45d68d617bc\","
+               + "\"type\":\"action.log_created\","
+               + "\"record\":{\"userId\":\"b9f74d36-fcfc-4efc-87f1-3664ab5a7fb0\",\"state\":\"ALLOW\"}"
+               + "}]"
+               + "}";
+
+        string signature = SignPayload(payload, 1740016316);
+
+        var batch = AuthsignalClient.Webhook.ConstructLogEventBatch(payload, signature, -1);
+
+        var logEvent = Assert.Single(batch.Records);
+
+        Assert.Equal("action.log_created", logEvent.Type);
+        Assert.Equal("ALLOW", logEvent.Record?["state"].GetString());
+    }
+
+    [Fact]
+    public void TestLogEventBatchPassedToConstructEventIsRejectedWithGuidance()
+    {
+        string payload = "{"
+               + "\"records\":[]"
+               + "}";
+
+        string signature = SignPayload(payload, 1740016316);
+
+        var ex = Assert.Throws<Webhook.InvalidPayloadException>(
+            () => AuthsignalClient.Webhook.ConstructEvent(payload, signature, -1));
+
+        Assert.Contains("ConstructLogEventBatch", ex.Message);
+    }
+
+    [Fact]
+    public void TestInvalidPayload()
+    {
+        const string payload = "not-json";
+
+        string signature = SignPayload(payload, 1740016316);
+
+        var ex = Assert.Throws<Webhook.InvalidPayloadException>(
+            () => AuthsignalClient.Webhook.ConstructEvent(payload, signature, -1));
+
+        Assert.Equal("Payload format is invalid.", ex.Message);
+        Assert.NotNull(ex.InnerException);
+    }
+
+    [Fact]
+    public void TestMissingRequiredEnvelopeField()
+    {
+        const string payload = "{\"version\":1,\"type\":\"sms.created\",\"data\":{}}";
+
+        string signature = SignPayload(payload, 1740016316);
+
+        var ex = Assert.Throws<Webhook.InvalidPayloadException>(
+            () => AuthsignalClient.Webhook.ConstructEvent(payload, signature, -1));
+
+        Assert.Equal("Payload is missing required field 'id'.", ex.Message);
     }
 }


### PR DESCRIPTION
### Breaking Changes

- Changed `WebhookEvent.Data` from `Dictionary<string, string>?` to `Dictionary<string, JsonElement>?` to support structured JSON values. Consumers must now use accessors such as `.GetString()`.
- Bumped the SDK to `5.0.0`.

### New Features

- Added support for `customVariables` in webhook events.
- Added `ConstructLogEventBatch` for batched log events.

### Bug Fixes

- Improved invalid webhook payload handling and validation.
- Fixed SDK version metadata.

### Checklist

- [x] Version bumped
- [ ] Documentation updated